### PR TITLE
modify default routing parameter on indexAction

### DIFF
--- a/src/AppBundle/Controller/BlogController.php
+++ b/src/AppBundle/Controller/BlogController.php
@@ -34,7 +34,7 @@ use AppBundle\Form\CommentType;
 class BlogController extends Controller
 {
     /**
-     * @Route("/", defaults={"page": 1}, name="blog_index")
+     * @Route("/", defaults={"page": "1"}, name="blog_index")
      * @Route("/page/{page}", requirements={"page": "[1-9]\d*"}, name="blog_index_paginated")
      * @Method("GET")
      * @Cache(smaxage="10")


### PR DESCRIPTION
I found `$page` parameter's type on default routing is different from that of  "/page/{page}" routing.
This difference seems not to be reasonable, then I fix it.